### PR TITLE
Escaped template strings + Added nested include support + More

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,24 @@ function importHtml(data, opts) {
             encoding: 'utf8'
         });
 
+        if (opts.nestedIncludes) {
+            read_file_content = read_file_content.replace(fileReg, (match, componentName) => {
+                let nested_include_content = fs.readFileSync(opts.componentsPath + componentName, {
+                    encoding: 'utf8'
+                });
+
+                if (opts.template) {
+                    for (let k in opts.template) {
+                        let k_reg = eval("/" + escapeRegExp(k) + "/g")
+                        nested_include_content = nested_include_content.replace(k_reg, opts.template[k])
+                    }
+                }
+                console.log('Nested @import: ' + opts.componentsPath + componentName)
+
+                return '<!-- import "' + componentName + '" -->\n' + nested_include_content + '\n' + IMPORT_END
+            })
+        }
+
         if (opts.template) {
             for (let k in opts.template) {
                 let k_reg = eval("/" + escapeRegExp(k) + "/g")


### PR DESCRIPTION
### Bug Fixes
This pull request fixes the following bugs:

- **Template strings Regex escaping bug** - Template entries with dollar signs or other regex characters would not be found and replaced correctly because the special characters were not escaped before they were used to create the Regex pattern. This pull request fixes this issue.

### New Features
This pull request adds the following new features:

- **Nested include support** - Users can now choose to enable nested include support using a "nestedIncludes" option. This will make the script search for include comment strings in the include files themselves.
- **Template string replacement in the base file** - The script will now also search for and replace template strings in the base file (a.k.a index.html)